### PR TITLE
修复tn-form-item 左侧图标leftIconStyle自定义样式不生效的bug，Update tn-form-item.vue。

### DIFF
--- a/tuniao-ui/components/tn-form-item/tn-form-item.vue
+++ b/tuniao-ui/components/tn-form-item/tn-form-item.vue
@@ -53,7 +53,7 @@
             <slot></slot>
           </view>
           <view v-if="$slots.right || rightIcon" class="tn-form-item--right__content__icon tn-flex">
-            <view v-if="rightIcon" :class="[`tn-icon-${rightIcon}`]" :style="rightIconStyle"></view>
+            <view v-if="rightIcon" :class="[`tn-icon-${rightIcon}`]" :style="[rightIconStyle]"></view>
             <slot name="right"></slot>
           </view>
         </view>


### PR DESCRIPTION
修复tn-form-item 左侧图标leftIconStyle自定义样式不生效的bug。